### PR TITLE
Replace cryptography, hashlib and hmac module with wolfcrypt

### DIFF
--- a/Finished.py
+++ b/Finished.py
@@ -1,5 +1,5 @@
 import logging
-import hmac
+
 from KeySchedule import KeySchedule
 
 class Finished:
@@ -10,7 +10,10 @@ class Finished:
 
     def set_expected_verify_data(self):
         # Calc the expected HMAC at client to validate server one
-        expected_verify_data = hmac.new(self.key_sched.get_s_finished(), self.key_sched.hashAlgo(self.key_sched.transcript).digest(), self.key_sched.hashAlgo).digest()
+        expected_verify_data = self.key_sched.hmacAlgo(
+            self.key_sched.get_s_finished(),
+            self.key_sched.hashAlgo(self.key_sched.transcript).digest()
+        ).digest()
         self.expected_verify_data = expected_verify_data
 
     def do(self, msg):
@@ -22,5 +25,9 @@ class Finished:
         return msg
 
     def make(self):
-        verify_data = hmac.new(self.key_sched.get_c_finished(), self.key_sched.hashAlgo(self.key_sched.transcript).digest(), self.key_sched.hashAlgo).digest()
+        verify_data = self.key_sched.hmacAlgo(
+            self.key_sched.get_c_finished(),
+            self.key_sched.hashAlgo(self.key_sched.transcript).digest(),
+        ).digest()
+
         return verify_data

--- a/KeyExchange.py
+++ b/KeyExchange.py
@@ -1,9 +1,5 @@
 import logging
 
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
-
 from KeySchedule import KeySchedule
 
 class KeyExchange:
@@ -16,16 +12,5 @@ class KeyExchange:
         self.keySched = keySched
 
     def doExchange(self, priv, pub):
-
-        logging.debug(f"Server Public: {''.join(f'{byte:02x}' for byte in pub)}")
-
-        priv_key = serialization.load_der_private_key(
-            priv, password=None, backend=default_backend()
-        )
-        pub_key = ec.EllipticCurvePublicKey.from_encoded_point(priv_key.curve, pub)
-
-        # Perform ECDH to derive the shared secret
-        shared_sec = priv_key.exchange(ec.ECDH(), pub_key)
-        print(shared_sec.hex())
-
+        shared_sec = priv.shared_secret(pub)
         self.keySched.set_shared_secret(shared_sec)


### PR DESCRIPTION
This PR replaces the cryptography, hashlib and hmac modules with the wolfcrypt.

The `testKeySchedule.py` uses the cryptography module but it's left unmodified in this PR.
It should be changed in other PR.